### PR TITLE
Better sub dispatch support

### DIFF
--- a/mcli/Dispatch.hx
+++ b/mcli/Dispatch.hx
@@ -448,7 +448,6 @@ class Dispatch
 			if (argDef == null)
 				if (arg != null) {
 					if (didCall == false) {
-						trace ("did not call something");
 						throw UnknownArgument(arg);
 					}
 					else continue;


### PR DESCRIPTION
These changes add some sub-dispatch fixes:
- Allow dispatch arguments on `runDefault` methods
- Don't throw `UnknownArgument` if there is a dispatch argument - assume it will be dealt with in a subdispatch or manually.
- Expose `dispatch.args` as read only so you can manually work with arguments

These changes are in line with some of the behaviour of `haxe.web.Dispatch`, which I use - so I think MCLI's dispatch is very cool.  (Would love to port the Decoder stuff back to `haxe.web.Dispatch` at some point!)
