### PR TITLE
Changed Map to Map.IMap

### DIFF
--- a/mcli/Dispatch.hx
+++ b/mcli/Dispatch.hx
@@ -317,7 +317,7 @@ class Dispatch
 				case Flag:
 					Reflect.setProperty(v, argDef.name, true);
 				case VarHash(key,val,arr):
-					var map:Map<Dynamic,Dynamic> = Reflect.getProperty(v, argDef.name);
+					var map:Map.IMap<Dynamic,Dynamic> = Reflect.getProperty(v, argDef.name);
 					var n = args.pop();
 					var toAdd = [];
 					while(n != null && n.charCodeAt(0) == '-'.code)


### PR DESCRIPTION
With the latest haxe/git I was getting the error:

```
/usr/lib/haxe/lib/mcli/0,1,2-beta/mcli/Dispatch.hx:320: characters 36-71 : Abstract Map has no @:to function that accepts IMap<Dynamic, Dynamic>
```

Changing the variable declaration to be typed as `Map.IMap` instead of `Map` works for everything except `[]` array access notation, which isn't used here anyway.

This line fixed the problem for me.
