### PR TITLE
Bandaid fix for nodejs

### DIFF
--- a/mcli/Dispatch.hx
+++ b/mcli/Dispatch.hx
@@ -310,7 +310,7 @@ using Lambda;
 
 	private function errln(s:String)
 	{
-#if sys
+#if (sys && !nodejs)
 		Sys.stderr().writeString(s + "\n");
 #else
 		haxe.Log.trace(s,null);


### PR DESCRIPTION
Sys.stderr, stdout, stdin are not implemented (yet) in hxnodejs